### PR TITLE
Automate updating stats in README

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,24 @@
+name: README stats update
+
+on: [push]
+
+jobs:
+  update_readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Update README stats
+        run: |
+          source scripts/calculate_stats.sh
+          awk -v var="$STATS" '/## Stats/{print var; p=1} !p' README.md > temp 
+          if cmp -s README.md temp; then
+            echo "README not updated."
+          else
+            mv temp README.md
+            echo "README has changed and therefore pushing the changes to git."
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config user.name "github-actions[bot]"
+            git commit -am "Automated stats update"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ java -jar target/BreakingUpdateAnalyzer.jar --help
 ```
 
 ## Stats
-As of Feb 12 2023:
-  * The dataset consists of 8466 breaking updates from 404 different projects.
-  * Reproduction has been attempted for 4750 (56.11%) of these breaking updates.
-    - Of these reproductions, 488 (10.27%) fail compilation with the updated dependency.
-    - 348 (7.33%) fail tests with the updated dependency.
-    - The remaining 3914 (82.40%) could not be locally reproduced.
+As of May 15 2023:
+  * The dataset consists of 11004 breaking updates from 422 different projects.
+  * Reproduction has been attempted for   4750 (43.17%)   of these breaking updates.
+    - Of these reproductions, 488     (10.27%) fail compilation with     the updated dependency.
+    - 348 (7.33%)     fail tests with the updated dependency.
+    - The remaining 3914 (82.40%)     could not be locally reproduced.

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ java -jar target/BreakingUpdateAnalyzer.jar --help
 ```
 
 ## Stats
-As of May 15 2023:
+As of May 16 2023:
   * The dataset consists of 11004 breaking updates from 422 different projects.
-  * Reproduction has been attempted for   4750 (43.17%)   of these breaking updates.
-    - Of these reproductions, 488     (10.27%) fail compilation with     the updated dependency.
-    - 348 (7.33%)     fail tests with the updated dependency.
-    - The remaining 3914 (82.40%)     could not be locally reproduced.
+  * Reproduction has been attempted for 4750 (43.17%) of these breaking updates.
+    - Of these reproductions, 488 (10.27%) fail compilation with the updated dependency.
+    - 348 (7.33%) fail tests with the updated dependency.
+    - The remaining 3914 (82.40%) could not be locally reproduced.

--- a/scripts/calculate_stats.sh
+++ b/scripts/calculate_stats.sh
@@ -18,6 +18,22 @@ num_unreproducible=$(find reproduction/unreproducible -type f | wc -l)
 num_reproduced=$(("$num_compilation_failure" + "$num_test_failure"))
 num_attempted=$(("$num_reproduced" + "$num_unreproducible"))
 
+# Create STATS variable to use in the README.
+STATS="## Stats
+As of $(LC_TIME=en_US.UTF-8 date +"%b %-d %Y"):
+  * The dataset consists of $num_breaking breaking updates from $num_repos different projects.
+  * Reproduction has been attempted for \
+  $num_attempted ($(get_fraction_as_percentage "$num_attempted" "$num_breaking")) \
+  of these breaking updates.
+    - Of these reproductions, $num_compilation_failure \
+    ($(get_fraction_as_percentage "$num_compilation_failure" "$num_attempted")) fail compilation with \
+    the updated dependency.
+    - $num_test_failure ($(get_fraction_as_percentage "$num_test_failure" "$num_attempted")) \
+    fail tests with the updated dependency.
+    - The remaining $num_unreproducible ($(get_fraction_as_percentage "$num_unreproducible" "$num_attempted")) \
+    could not be locally reproduced."
+export STATS
+
 # Print nicely formatted stats
 printf "As of %s:\n" "$(LC_TIME=en_US.UTF-8 date +"%b %-d %Y")"
 printf "  * The dataset consists of %d breaking updates from %d different projects.\n" \

--- a/scripts/calculate_stats.sh
+++ b/scripts/calculate_stats.sh
@@ -22,27 +22,8 @@ num_attempted=$(("$num_reproduced" + "$num_unreproducible"))
 STATS="## Stats
 As of $(LC_TIME=en_US.UTF-8 date +"%b %-d %Y"):
   * The dataset consists of $num_breaking breaking updates from $num_repos different projects.
-  * Reproduction has been attempted for \
-  $num_attempted ($(get_fraction_as_percentage "$num_attempted" "$num_breaking")) \
-  of these breaking updates.
-    - Of these reproductions, $num_compilation_failure \
-    ($(get_fraction_as_percentage "$num_compilation_failure" "$num_attempted")) fail compilation with \
-    the updated dependency.
-    - $num_test_failure ($(get_fraction_as_percentage "$num_test_failure" "$num_attempted")) \
-    fail tests with the updated dependency.
-    - The remaining $num_unreproducible ($(get_fraction_as_percentage "$num_unreproducible" "$num_attempted")) \
-    could not be locally reproduced."
+  * Reproduction has been attempted for $num_attempted ($(get_fraction_as_percentage "$num_attempted" "$num_breaking")) of these breaking updates.
+    - Of these reproductions, $num_compilation_failure ($(get_fraction_as_percentage "$num_compilation_failure" "$num_attempted")) fail compilation with the updated dependency.
+    - $num_test_failure ($(get_fraction_as_percentage "$num_test_failure" "$num_attempted")) fail tests with the updated dependency.
+    - The remaining $num_unreproducible ($(get_fraction_as_percentage "$num_unreproducible" "$num_attempted")) could not be locally reproduced."
 export STATS
-
-# Print nicely formatted stats
-printf "As of %s:\n" "$(LC_TIME=en_US.UTF-8 date +"%b %-d %Y")"
-printf "  * The dataset consists of %d breaking updates from %d different projects.\n" \
-       "$num_breaking" "$num_repos"
-printf "  * Reproduction has been attempted for %s (%s) of these breaking updates.\n" \
-       "$num_attempted" "$(get_fraction_as_percentage "$num_attempted" "$num_breaking")"
-printf "    - Of these reproductions, %s (%s) fail compilation with the updated dependency.\n" \
-       "$num_compilation_failure" "$(get_fraction_as_percentage "$num_compilation_failure" "$num_attempted")"
-printf "    - %s (%s) fail tests with the updated dependency.\n" \
-       "$num_test_failure" "$(get_fraction_as_percentage "$num_test_failure" "$num_attempted")"
-printf "    - The remaining %s (%s) could not be locally reproduced.\n" \
-       "$num_unreproducible" "$(get_fraction_as_percentage "$num_unreproducible" "$num_attempted")"


### PR DESCRIPTION
### Description
Automate updating stats section in the README using GitHub actions. But for this to work, workflows should be given read and write permissions in the repository. 

### Related Issues
- https://github.com/chains-project/breaking-updates/issues/36