### PR TITLE
Add the option to reproduce all existing breaking updates

### DIFF
--- a/src/main/java/reproducer/BreakingUpdateReproducer.java
+++ b/src/main/java/reproducer/BreakingUpdateReproducer.java
@@ -64,20 +64,16 @@ public class BreakingUpdateReproducer {
      * @param breakingUpdates the list of breaking updates to reproduce.
      */
     public void reproduceAll(File[] breakingUpdates) {
-        if (breakingUpdates.length > 0) {
-            for (File breakingUpdate : breakingUpdates) {
-                try {
-                    BreakingUpdate bu = JsonUtils.readFromFile(breakingUpdate.toPath(), BreakingUpdate.class);
-                    if (bu.getReproductionStatus().equals("not_attempted")) {
-                        reproduce(bu);
-                    }
-                } catch (RuntimeException e) {
-                    log.error("An exception occurred while reproducing the breaking update in " +
-                            breakingUpdate.getName(), e);
+        for (File breakingUpdate : breakingUpdates) {
+            try {
+                BreakingUpdate bu = JsonUtils.readFromFile(breakingUpdate.toPath(), BreakingUpdate.class);
+                if (bu.getReproductionStatus().equals("not_attempted")) {
+                    reproduce(bu);
                 }
+            } catch (RuntimeException e) {
+                log.error("An exception occurred while reproducing the breaking update in " +
+                        breakingUpdate.getName(), e);
             }
-        } else {
-            throw new RuntimeException("The provided directory containing breaking updates is empty.");
         }
     }
 

--- a/src/main/java/reproducer/BreakingUpdateReproducer.java
+++ b/src/main/java/reproducer/BreakingUpdateReproducer.java
@@ -12,9 +12,11 @@ import com.github.dockerjava.okhttp.OkDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
 import miner.BreakingUpdate;
 import miner.BreakingUpdate.Analysis.ReproductionLabel;
+import miner.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.*;
 
 /**
@@ -54,6 +56,28 @@ public class BreakingUpdateReproducer {
             ensureBaseMavenImageExists();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Iterate through a list of breaking updates and attempt to reproduce if not already attempted.
+     * @param breakingUpdates the list of breaking updates to reproduce.
+     */
+    public void reproduceAll(File[] breakingUpdates) {
+        if (breakingUpdates.length > 0) {
+            for (File breakingUpdate : breakingUpdates) {
+                try {
+                    BreakingUpdate bu = JsonUtils.readFromFile(breakingUpdate.toPath(), BreakingUpdate.class);
+                    if (bu.getReproductionStatus().equals("not_attempted")) {
+                        reproduce(bu);
+                    }
+                } catch (RuntimeException e) {
+                    log.error("An exception occurred while reproducing the breaking update in " +
+                            breakingUpdate.getName(), e);
+                }
+            }
+        } else {
+            throw new RuntimeException("The provided directory containing breaking updates is empty.");
         }
     }
 

--- a/src/main/java/reproducer/Main.java
+++ b/src/main/java/reproducer/Main.java
@@ -4,6 +4,7 @@ import miner.BreakingUpdate;
 import miner.JsonUtils;
 import picocli.CommandLine;
 
+import java.io.File;
 import java.nio.file.Path;
 
 /**
@@ -27,7 +28,7 @@ public class Main {
         @CommandLine.Option(
                 names = {"-d", "--dataset-dir"},
                 paramLabel = "DATASET-DIR",
-                description = "The directory where breaking update information should be written.",
+                description = "The directory where breaking update information are written.",
                 required = true
         )
         Path datasetDir;
@@ -51,8 +52,7 @@ public class Main {
         @CommandLine.Option(
                 names = {"-f", "--file"},
                 paramLabel = "BREAKING-UPDATE-FILE",
-                description = "A JSON file describing a breaking update.",
-                required = true
+                description = "A JSON file describing a breaking update."
         )
         Path breakingUpdateFile;
 
@@ -60,8 +60,13 @@ public class Main {
         public void run() {
             ResultManager resultManager = new ResultManager(datasetDir, reproductionDir, jarDir);
             BreakingUpdateReproducer reproducer = new BreakingUpdateReproducer(resultManager);
-            BreakingUpdate bu = JsonUtils.readFromFile(breakingUpdateFile, BreakingUpdate.class);
-            reproducer.reproduce(bu);
+            if (breakingUpdateFile != null) {
+                BreakingUpdate bu = JsonUtils.readFromFile(breakingUpdateFile, BreakingUpdate.class);
+                reproducer.reproduce(bu);
+            } else {
+                File[] breakingUpdates = datasetDir.toFile().listFiles();
+                reproducer.reproduceAll(breakingUpdates);
+            }
         }
     }
 }

--- a/src/main/java/reproducer/Main.java
+++ b/src/main/java/reproducer/Main.java
@@ -67,7 +67,11 @@ public class Main {
                 reproducer.reproduce(bu);
             } else {
                 File[] breakingUpdates = datasetDir.toFile().listFiles();
-                reproducer.reproduceAll(breakingUpdates);
+                if (breakingUpdates.length > 0) {
+                    reproducer.reproduceAll(breakingUpdates);
+                } else {
+                    throw new RuntimeException("The provided directory containing breaking updates is empty.");
+                }
             }
         }
     }


### PR DESCRIPTION
Previously, the user had to specify the JSON files containing the breaking updates one by one to reproduce each. Instead of that, if the user had not specified a JSON file and reproduction is not attempted previously, all the JSON files in the dataset directory will be attempted to reproduce. If a JSON file is specified, only that breaking update will be reproduced as before. 