### PR TITLE
Exclude PRs from renovate in update-readme.yml

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   update_readme:
+    if: github.actor!= 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ java -jar target/BreakingUpdateAnalyzer.jar --help
 ```
 
 ## Stats
-As of May 21 2023:
+As of Jun 7 2023:
   * The dataset consists of 11004 breaking updates from 422 different projects.
   * Reproduction has been attempted for 4750 (43.17%) of these breaking updates.
     - Of these reproductions, 488 (10.27%) fail compilation with the updated dependency.


### PR DESCRIPTION
Avoid updating the readme when the PR is from Renovate.