### PR TITLE
Update the JSON data files with the metadata and remove dependencies with the scope test

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ the format:
     "versionUpdateType": "{major|minor|patch|other}",
     "type": "{human|renovate|dependabot|other}",
     "reproductionStatus": "{not_attempted|successful|unreproducible}",
-    "analysis": "<json object corresponding to the specification below>"
+    "analysis": "<json object of collected analysis data as specified below>",
+    "metadata": "<json object of collected metadata as specified below>"
 }
 ```
 
@@ -35,13 +36,19 @@ The data gathering workflow is as follows:
 * Stage 1 : we look at Github metadata
 * Stage 2: (WIP) we save the commit <commit_id> in a branch called "branch-<project_slug>-<commit_id>" in this repo. 
 * Stage 3: (WIP) reproduce the failure locally under the assumptions documented below. This will introduce the following analysis 
-  data to the breaking update JSON format:
+  data and metadata to the breaking update JSON format:
   ```json
   {
-    "labels": ["DEPENDENCY_RESOLUTION_FAILURE", "MAVEN_ENFORCER_FAILURE", "COMPILATION_FAILURE", 
-               "TEST_FAILURE", "UNKNOWN_FAILURE"], 
-    "reproductionLogLocation": "reproduction/{successful|unreproducible}/<sha>.log",
-    "javaVersionUsedForLocalReproduction": "11"
+    "analysis" : {
+      "labels" : [ "<label indicating the status of the reproduction>" ],
+      "javaVersionUsedForReproduction" : "<used java version>",
+      "reproductionLogLocation" : "<location of the saved reproduction log file>"
+    },
+    "metadata" : {
+      "compareLink" : "<the github comparison link for the old and new tag releases of the updated dependency if it exists>",
+      "mavenSourceLinks" : [ "<maven source jar links for the old and new releases of the updated dependency if they exist>"],
+      "updateType" : "{pom|jar}"
+    }
   }
   ```
   * Assumptions:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ java -jar target/BreakingUpdateReproducer.jar --help
 ```
 
 ## Stats
-As of Jun 16 2023:
+As of Jun 19 2023:
   * The dataset consists of 11004 breaking updates from 422 different projects.
   * Reproduction has been attempted for 4750 (43.17%) of these breaking updates.
     - Of these reproductions, 488 (10.27%) fail compilation with the updated dependency.

--- a/schemas/breaking-update-metadata.schema.json
+++ b/schemas/breaking-update-metadata.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/chains-project/breaking-updates/blob/main/schemas/breaking-update-metadata.schema.json",
+  "title": "Breaking Update",
+  "description": "Metadata for the local reproduction of a breaking update.",
+  "type": "object",
+  "properties": {
+    "compareLink": {
+      "description": "The comparison link of the two GitHub tags that correspond to the old and new versions of the updated dependency.",
+      "type": ["string", "null"]
+    },
+    "mavenSourceLinks": {
+      "description": "The maven source links of the old and new versions of the updated dependency.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minItems": 2,
+            "uniqueItems": true
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "updateType": {
+      "description": "The type of the updated dependency.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "POM",
+            "JAR"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/breaking-update.schema.json
+++ b/schemas/breaking-update.schema.json
@@ -79,6 +79,17 @@
           "type": "null"
         }
       ]
+    },
+    "metadata": {
+      "description": "The metadata for any local reproduction attempts",
+      "anyOf": [
+        {
+          "$ref": "./breaking-update-metadata.schema.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "required": [

--- a/src/main/java/miner/BreakingUpdate.java
+++ b/src/main/java/miner/BreakingUpdate.java
@@ -26,6 +26,8 @@ public class BreakingUpdate {
     private static final Pattern PREVIOUS_VERSION =
             Pattern.compile("^-\\s*<version>(.*)</version>\\s*$");
     private static final Pattern NEW_VERSION = Pattern.compile("^\\+\\s*<version>(.*)</version>\\s*$");
+    private static final Pattern SCOPE =
+            Pattern.compile("^\\s*<scope>(.*)</scope>\\s*$");
     private static final Pattern SEM_VER = Pattern.compile("^\\d+\\.\\d+\\.\\d+$");
 
     public final String url;
@@ -36,6 +38,7 @@ public class BreakingUpdate {
     public final String dependencyArtifactID;
     public final String previousVersion;
     public final String newVersion;
+    public final String dependencyScope;
     public final String versionUpdateType;
     public final String type;
     private String reproductionStatus = "not_attempted";
@@ -60,6 +63,7 @@ public class BreakingUpdate {
         dependencyArtifactID = parsePatch(pr, DEPENDENCY_ARTIFACT_ID, "unknown");
         previousVersion = parsePatch(pr, PREVIOUS_VERSION, "unknown");
         newVersion = parsePatch(pr, NEW_VERSION, "unknown");
+        dependencyScope = parsePatch(pr, SCOPE, "unknown");
         versionUpdateType = parseVersionUpdateType(previousVersion, newVersion);
         type = parseType(pr);
     }
@@ -75,6 +79,7 @@ public class BreakingUpdate {
                            @JsonProperty("dependencyArtifactID") String dependencyArtifactID,
                            @JsonProperty("previousVersion") String previousVersion,
                            @JsonProperty("newVersion") String newVersion,
+                           @JsonProperty("dependencyScope") String dependencyScope,
                            @JsonProperty("versionUpdateType") String versionUpdateType,
                            @JsonProperty("type") String type,
                            @JsonProperty("reproductionStatus") String reproductionStatus,
@@ -88,6 +93,7 @@ public class BreakingUpdate {
         this.dependencyArtifactID = dependencyArtifactID;
         this.previousVersion = previousVersion;
         this.newVersion = newVersion;
+        this.dependencyScope = dependencyScope;
         this.versionUpdateType = versionUpdateType;
         this.type = type;
         this.reproductionStatus = reproductionStatus;

--- a/src/main/java/miner/BreakingUpdate.java
+++ b/src/main/java/miner/BreakingUpdate.java
@@ -216,7 +216,7 @@ public class BreakingUpdate {
     }
 
     /**
-     * @return Metadata of this breaking update. Note that if the {@code reproductionStatus} of this breaking
+     *Returns metadata of this breaking update. Note that if the {@code reproductionStatus} of this breaking
      *         update is "not_attempted", metadata will be {@code null}.
      */
     public Metadata getMetadata() {

--- a/src/main/java/miner/BreakingUpdate.java
+++ b/src/main/java/miner/BreakingUpdate.java
@@ -40,6 +40,7 @@ public class BreakingUpdate {
     public final String type;
     private String reproductionStatus = "not_attempted";
     private Analysis analysis = null;
+    private Metadata metadata = null;
 
     /**
      * Create a new BreakingUpdate object that stores information about a
@@ -77,7 +78,8 @@ public class BreakingUpdate {
                            @JsonProperty("versionUpdateType") String versionUpdateType,
                            @JsonProperty("type") String type,
                            @JsonProperty("reproductionStatus") String reproductionStatus,
-                           @JsonProperty("analysis") Analysis analysis) {
+                           @JsonProperty("analysis") Analysis analysis,
+                           @JsonProperty("metadata") Metadata metadata){
         this.url = url;
         this.project = project;
         this.commit = commit;
@@ -90,6 +92,7 @@ public class BreakingUpdate {
         this.type = type;
         this.reproductionStatus = reproductionStatus;
         this.analysis = analysis;
+        this.metadata = metadata;
     }
 
 
@@ -199,6 +202,22 @@ public class BreakingUpdate {
     }
 
     /**
+     * Update metadata of this breaking update.
+     * @param metadata the new metadata to add to this breaking update.
+     */
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * @return Metadata of this breaking update. Note that if the {@code reproductionStatus} of this breaking
+     *         update is "not_attempted", metadata will be {@code null}.
+     */
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    /**
      * The Analysis class represents data associated with the reproduction and analysis of a breaking update.
      */
     public static class Analysis {
@@ -262,5 +281,38 @@ public class BreakingUpdate {
                 return this.compareTo(COMPILATION_FAILURE) >= 0;
             }
         }
+    }
+
+    /**
+     * Metadata represents metadata associated with the reproduction and analysis of a breaking update.
+     */
+    public record Metadata(String compareLink, List<String> mavenSourceLinks, BreakingUpdate.Metadata.UpdateType updateType) {
+        /**
+         * Create metadata of this breaking update.
+         *
+         * @param compareLink      the comparison link of two GitHub tags where the two tags correspond to the old and
+         *                         new versions of the dependency involved in the breaking update.
+         * @param mavenSourceLinks the maven source links of the old and new versions of the dependency involved
+         *                         in the breaking update.
+         * @param updateType       the type of the updated dependency.
+         */
+        @JsonCreator
+        public Metadata(@JsonProperty("compareLink") String compareLink,
+                        @JsonProperty("mavenSourceLinks") List<String> mavenSourceLinks,
+                        @JsonProperty("updateType") UpdateType updateType) {
+            this.compareLink = compareLink;
+            this.mavenSourceLinks = mavenSourceLinks;
+            this.updateType = updateType;
+        }
+
+        /**
+         * The type of the updated dependency, indicating whether it is a pom type dependency where a jar file will
+         * not be collected, or a jar type dependency where a jar file will be downloaded.
+         */
+        public enum UpdateType {
+            POM,
+            JAR,
+        }
+
     }
 }

--- a/src/main/java/miner/GitHubMiner.java
+++ b/src/main/java/miner/GitHubMiner.java
@@ -177,8 +177,10 @@ public class GitHubMiner {
                     .filter(PullRequestFilters.breaksBuild)
                     .map(BreakingUpdate::new)
                     .forEach(breakingUpdate -> {
-                        writeBreakingUpdate(breakingUpdate);
-                        System.out.println("    Found " + breakingUpdate.url);
+                        if (!breakingUpdate.dependencyScope.equals("test")) {
+                            writeBreakingUpdate(breakingUpdate);
+                            System.out.println("    Found " + breakingUpdate.url);
+                        }
                     });
         }
     }

--- a/src/main/java/reproducer/MetadataFinder.java
+++ b/src/main/java/reproducer/MetadataFinder.java
@@ -1,0 +1,89 @@
+package reproducer;
+
+import miner.BreakingUpdate;
+import miner.GitHubAPITokenQueue;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHTag;
+import org.kohsuke.github.PagedIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The MetadataFinder involves in resolving metadata of reproduction results. Metadata includes GitHub comparison links,
+ * Maven source links and dependency update types.
+ */
+public class MetadataFinder {
+
+    private final OkHttpClient httpConnector;
+    private final GitHubAPITokenQueue tokenQueue;
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    /**
+     * @param apiTokens a collection of GitHub API tokens.
+     * @throws IOException if there is an issue connecting to the GitHub servers.
+     */
+    public MetadataFinder(Collection<String> apiTokens) throws IOException {
+        httpConnector = new OkHttpClient.Builder()
+                .connectTimeout(60, TimeUnit.SECONDS)
+                .writeTimeout(120, TimeUnit.SECONDS)
+                .readTimeout(60, TimeUnit.SECONDS).build();
+        tokenQueue = new GitHubAPITokenQueue(apiTokens);
+    }
+
+    /** Get the GitHub comparison links for the old and new tag releases if they exist. */
+    public String getCompareLink(BreakingUpdate bu) {
+
+        try {
+            GHRepository repository = tokenQueue.getGitHub(httpConnector).getRepository(bu.project);
+            List<String> tags = getTags(repository, bu.previousVersion, bu.newVersion);
+            String repositoryURL = repository.getUrl().toString();
+            return (tags != null) ? (repositoryURL + "/compare/" + tags.get(0) + "..." + tags.get(1)) : null;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Get the old and new tag releases if they exist in GitHub. */
+    private List<String> getTags(GHRepository repository, String prevVersion, String newVersion) {
+        try {
+            PagedIterable<GHTag> allTags = repository.listTags();
+            List<String> tags = allTags.toList().stream()
+                    .filter(tag -> tag.getName().contains(prevVersion) || tag.getName().contains(newVersion))
+                    .map(GHTag::getName)
+                    .sorted(Comparator.comparing(found -> !found.contains(prevVersion)))
+                    .toList();
+            return tags.size() == 2 ? tags : null;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Get the Maven source links for the old and new dependency releases if they exist. */
+    public List<String> getMavenSourceLinks(BreakingUpdate bu) {
+        String mavenSourceLinkBase = "https://repo1.maven.org/maven2/%s/%s/"
+                .formatted(bu.dependencyGroupID.replaceAll("\\.", "/"), bu.dependencyArtifactID);
+        String prevVersionMavenSourceLink = mavenSourceLinkBase + "%s/%s-%s-sources.jar"
+                .formatted(bu.previousVersion, bu.dependencyArtifactID, bu.previousVersion);
+        String newVersionMavenSourceLink = mavenSourceLinkBase + "%s/%s-%s-sources.jar"
+                .formatted(bu.newVersion, bu.dependencyArtifactID, bu.newVersion);
+        try (Response prevSourceResponse = httpConnector.newCall(new Request.Builder().url(prevVersionMavenSourceLink)
+                .build()).execute();
+             Response newSourceResponse = httpConnector.newCall(new Request.Builder().url(newVersionMavenSourceLink)
+                .build()).execute()) {
+            if (prevSourceResponse.code() == 404 || newSourceResponse.code() == 404) return null;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return List.of(prevVersionMavenSourceLink, newVersionMavenSourceLink);
+    }
+
+}

--- a/src/main/java/reproducer/ResultManager.java
+++ b/src/main/java/reproducer/ResultManager.java
@@ -7,6 +7,7 @@ import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.okhttp.OkDockerHttpClient;
 import miner.BreakingUpdate;
 import miner.BreakingUpdate.Analysis.ReproductionLabel;
+import miner.BreakingUpdate.Metadata.UpdateType;
 import miner.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,9 +15,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -46,6 +45,7 @@ public class ResultManager {
     private final Path jarDir;
     private final Path successfulReproductionDir;
     private final Path unreproducibleReproductionDir;
+    private final Collection<String> apiTokens;
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     public static final Map<Pattern, BreakingUpdate.Analysis.ReproductionLabel> FAILURE_PATTERNS = new HashMap<>();
@@ -62,16 +62,18 @@ public class ResultManager {
     }
 
     /**
-     * @param datasetDir the directory where breaking update json files should be written.
+     * @param datasetDir      the directory where breaking update json files should be written.
      * @param reproductionDir the directory where maven logs should be stored.
-     * @param jarDir the directory where jar files corresponding to changed dependencies should be stored.
+     * @param jarDir          the directory where jar files corresponding to changed dependencies should be stored.
      */
-    public ResultManager(Path datasetDir, Path reproductionDir, Path jarDir) {
+    public ResultManager(Collection<String> apiTokens, Path datasetDir, Path reproductionDir, Path jarDir)
+            throws IOException {
         var config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
         this.client = DockerClientImpl.getInstance(config,
                 new OkDockerHttpClient.Builder().dockerHost(config.getDockerHost()).build());
         this.datasetDir = datasetDir;
         this.jarDir = jarDir;
+        this.apiTokens = apiTokens;
         successfulReproductionDir = reproductionDir.resolve("successful");
         unreproducibleReproductionDir = reproductionDir.resolve("unreproducible");
         if (Files.notExists(successfulReproductionDir) || Files.notExists(unreproducibleReproductionDir)) {
@@ -111,20 +113,32 @@ public class ResultManager {
         ReproductionLabel label = getReproductionLabel(logOutputLocation);
 
         log.info("Storing result {} for breaking update {}", label, bu.commit);
-        // Update breaking update file.
+        // Set reproduction status of the breaking update.
         bu.setReproductionStatus("successful");
+        // Set analysis of the breaking update.
         bu.setAnalysis(new BreakingUpdate.Analysis(List.of(label), logOutputLocation.toString()));
+        // Set metadata of the breaking update.
+        UpdateType updateType = extractDependencies(bu, containerId, prevContainerId);
+        try {
+            MetadataFinder metadataFinder = new MetadataFinder(apiTokens);
+            bu.setMetadata(new BreakingUpdate.Metadata(metadataFinder.getCompareLink(bu),
+                    metadataFinder.getMavenSourceLinks(bu), updateType));
+        } catch (IOException e) {
+            log.error("Metadata could not be fetched for the breaking update {}.", bu.commit, e);
+        }
+        // Update breaking update file.
         JsonUtils.writeToFile(datasetDir.resolve(bu.commit + JsonUtils.JSON_FILE_ENDING), bu);
 
         // Create docker images if reproduction was successful.
-        copyJars(bu, containerId, prevContainerId);
         log.info("Creating images for breaking update {}", bu.commit);
         createImage(bu, prevContainerId, PRECEDING_COMMIT_CONTAINER_TAG);
         createImage(bu, containerId, BREAKING_UPDATE_COMMIT_CONTAINER_TAG);
         // TODO: Push container to repository
     }
 
-    /** Remove JSON data when the reproduction is unsuccessful. */
+    /**
+     * Remove JSON data when the reproduction is unsuccessful.
+     */
     public void removeResult(BreakingUpdate bu, String containerId) {
         Path logOutputLocation = storeLogFile(bu, containerId, false);
         log.info("Removing the JSON file containing an unreproducible breaking update {}", bu.commit);
@@ -133,14 +147,18 @@ public class ResultManager {
                 , bu.commit);
     }
 
-    /** Copy old/new pair of dependency jar/pom files from the corresponding containers */
-    private void copyJars(BreakingUpdate bu, String containerId, String prevContainerId) {
+    /**
+     * Copy old/new pair of dependency jar/pom files from the corresponding containers.
+     *
+     * @return the type of the updated dependency.
+     */
+    public UpdateType extractDependencies(BreakingUpdate bu, String containerId, String prevContainerId) {
         String dependencyLocationBase = "/root/.m2/repository/%s/%s/"
                 .formatted(bu.dependencyGroupID.replaceAll("\\.", "/"), bu.dependencyArtifactID);
         for (String type : List.of("jar", "pom")) {
+            UpdateType updateType = UpdateType.valueOf(type.toUpperCase(Locale.ENGLISH));
             String oldDependencyLocation = dependencyLocationBase + "%s/%s-%s.%s"
                     .formatted(bu.previousVersion, bu.dependencyArtifactID, bu.previousVersion, type);
-
             try (InputStream dependencyStream = client.copyArchiveFromContainerCmd
                     (prevContainerId, oldDependencyLocation).exec()) {
                 Path dir = Files.createDirectories(jarDir
@@ -150,38 +168,40 @@ public class ResultManager {
                 Files.write(dir.resolve(fileName), dependencyStream.readAllBytes());
             } catch (NotFoundException e) {
                 if (type.equals("jar")) {
-                    log.info("Could not find the old jar for breaking update {}. Searching for a pom instead...",
-                            bu.commit);
+                    log.info("Could not find the old jar for breaking update %s. Searching for a pom instead..."
+                            .formatted(bu.commit));
                 } else {
                     log.error("Could not find the old jar or pom for breaking update {}", bu.commit);
                 }
                 continue;
             } catch (IOException e) {
-                log.error("Could not store the old {} for breaking update {}.", type, bu.commit, e);
+                log.error("Could not store the old %s for breaking update %s.".formatted(type, bu.commit), e);
             }
 
             String newDependencyLocation = dependencyLocationBase + "%s/%s-%s.%s"
                     .formatted(bu.newVersion, bu.dependencyArtifactID, bu.newVersion, type);
-            try (InputStream jarStream = client.copyArchiveFromContainerCmd(containerId, newDependencyLocation).exec()) {
+            try (InputStream dependencyStream = client.copyArchiveFromContainerCmd(containerId, newDependencyLocation).exec()) {
                 Path dir = Files.createDirectories(jarDir
                         .resolve(bu.dependencyGroupID.replaceAll("\\.", "/"))
                         .resolve(bu.newVersion));
                 String fileName = "%s-%s.%s".formatted(bu.dependencyArtifactID, bu.newVersion, type);
-                Files.write(dir.resolve(fileName), jarStream.readAllBytes());
-                break;
+                Files.write(dir.resolve(fileName), dependencyStream.readAllBytes());
+                return updateType;
             } catch (NotFoundException e) {
                 if (type.equals("jar")) {
-                    log.error("Could not find the new jar for breaking update {}, even if the old jar exists.",
-                            bu.commit);
-                    break;
+                    log.error("Could not find the new jar for breaking update %s, even if the old jar exists."
+                            .formatted(bu.commit));
+                    return updateType;
                 } else {
-                    log.error("Could not find the new pom for breaking update {}, even if the old pom exists.",
-                            bu.commit);
+                    log.error("Could not find the new pom for breaking update %s, even if the old pom exists."
+                            .formatted(bu.commit));
                 }
             } catch (IOException e) {
-                log.error("Could not store the new {} for breaking update {}.", type, bu.commit, e);
+                log.error("Could not store the new %s for breaking update %s.".formatted(type, bu.commit), e);
             }
+            return updateType;
         }
+        return null;
     }
 
     /**

--- a/src/main/java/reproducer/ResultManager.java
+++ b/src/main/java/reproducer/ResultManager.java
@@ -26,7 +26,9 @@ import java.util.regex.Pattern;
  */
 public class ResultManager {
 
-    /** The repository where the created images will be stored */
+    /**
+     * The repository where the created images will be stored
+     */
     private static final String REPOSITORY = "ghcr.io/chains-project/breaking-updates";
 
     /**
@@ -88,10 +90,11 @@ public class ResultManager {
         }
     }
 
-    /** Store the log file of the reproduction attempt. */
-    public Path storeLogFile(BreakingUpdate bu, String containerId, Boolean isReproducible) {
+    /**
+     * Store the log file of the reproduction attempt.
+     */
+    private Path storeLogFile(BreakingUpdate bu, String containerId, Boolean isReproducible) {
 
-        log.info("Storing the log file for breaking update {}", bu.commit);
         // Save log result in reproduction dir.
         Path outputDir = isReproducible ? successfulReproductionDir : unreproducibleReproductionDir;
         Path logOutputLocation = outputDir.resolve(bu.commit + ".log");
@@ -105,10 +108,22 @@ public class ResultManager {
         }
     }
 
-    /** Store results when the reproduction is successful. */
+    /**
+     * Delete the log file of the reproduction attempt from the wrong directory.
+     */
+    public void removeLogFile(BreakingUpdate bu, String directory) {
+        Path outputDir = directory.equals("successful") ? successfulReproductionDir : unreproducibleReproductionDir;
+        boolean isRemovingSuccessful = outputDir.resolve(bu.commit + ".log").toFile().delete();
+        if (!isRemovingSuccessful) log.error("Could not remove the log file from the {} reproduction directory for the "
+                + "breaking update {}", directory, bu.commit);
+    }
+
+    /**
+     * Store results when the reproduction is successful.
+     */
     public void storeResult(BreakingUpdate bu, String containerId, String prevContainerId) {
 
-        Path logOutputLocation = storeLogFile(bu, containerId, true);
+        Path logOutputLocation = successfulReproductionDir.resolve(bu.commit + ".log");
         // Get reproduction label.
         ReproductionLabel label = getReproductionLabel(logOutputLocation);
 
@@ -139,8 +154,7 @@ public class ResultManager {
     /**
      * Remove JSON data when the reproduction is unsuccessful.
      */
-    public void removeResult(BreakingUpdate bu, String containerId) {
-        Path logOutputLocation = storeLogFile(bu, containerId, false);
+    public void removeResult(BreakingUpdate bu) {
         log.info("Removing the JSON file containing an unreproducible breaking update {}", bu.commit);
         boolean isRemovingSuccessful = datasetDir.resolve(bu.commit + JsonUtils.JSON_FILE_ENDING).toFile().delete();
         if (!isRemovingSuccessful) log.error("Could not remove the JSON file of unreproducible breaking update {}"
@@ -152,7 +166,7 @@ public class ResultManager {
      *
      * @return the type of the updated dependency.
      */
-    public UpdateType extractDependencies(BreakingUpdate bu, String containerId, String prevContainerId) {
+    private UpdateType extractDependencies(BreakingUpdate bu, String containerId, String prevContainerId) {
         String dependencyLocationBase = "/root/.m2/repository/%s/%s/"
                 .formatted(bu.dependencyGroupID.replaceAll("\\.", "/"), bu.dependencyArtifactID);
         for (String type : List.of("jar", "pom")) {
@@ -168,14 +182,14 @@ public class ResultManager {
                 Files.write(dir.resolve(fileName), dependencyStream.readAllBytes());
             } catch (NotFoundException e) {
                 if (type.equals("jar")) {
-                    log.info("Could not find the old jar for breaking update %s. Searching for a pom instead..."
-                            .formatted(bu.commit));
+                    log.info("Could not find the old jar for breaking update {}. Searching for a pom instead...",
+                            bu.commit);
                 } else {
                     log.error("Could not find the old jar or pom for breaking update {}", bu.commit);
                 }
                 continue;
             } catch (IOException e) {
-                log.error("Could not store the old %s for breaking update %s.".formatted(type, bu.commit), e);
+                log.error("Could not store the old {} for breaking update {}.", type, bu.commit, e);
             }
 
             String newDependencyLocation = dependencyLocationBase + "%s/%s-%s.%s"
@@ -189,15 +203,15 @@ public class ResultManager {
                 return updateType;
             } catch (NotFoundException e) {
                 if (type.equals("jar")) {
-                    log.error("Could not find the new jar for breaking update %s, even if the old jar exists."
-                            .formatted(bu.commit));
+                    log.error("Could not find the new jar for breaking update {}, even if the old jar exists.",
+                            bu.commit);
                     return updateType;
                 } else {
-                    log.error("Could not find the new pom for breaking update %s, even if the old pom exists."
-                            .formatted(bu.commit));
+                    log.error("Could not find the new pom for breaking update {}, even if the old pom exists.",
+                            bu.commit);
                 }
             } catch (IOException e) {
-                log.error("Could not store the new %s for breaking update %s.".formatted(type, bu.commit), e);
+                log.error("Could not store the new {} for breaking update {}.", type, bu.commit, e);
             }
             return updateType;
         }
@@ -222,6 +236,14 @@ public class ResultManager {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Check whether the build failed due to test failures.
+     */
+    public Boolean isTestFailure(BreakingUpdate bu, String containerId, Boolean isReproducible) {
+        Path logOutputLocation = storeLogFile(bu, containerId, isReproducible);
+        return getReproductionLabel(logOutputLocation).equals(BreakingUpdate.Analysis.ReproductionLabel.TEST_FAILURE);
     }
 
     private void createImage(BreakingUpdate bu, String containerId, String extraTag) {


### PR DESCRIPTION
This PR will fix the following issues.

- Fixes #62 

> Update type (pom or jar) is added as a metadata to the JSON file.

- Fixes #63 

> GitHub compare link is added as a metadata to the JSON file if such link exists. If a GitHub repository cannot be found for the dependency, the message "A GitHub repository could not be found for the updated dependency." will be added for the compare link. If relevant tags could not be found even if a repository exists, "Relevant tags were not found in the GitHub repository <repoName> for the updated dependency." will be added. 
Here, the domain of the dependency groupID ("apache" in "org.apache.maven.plugins") is considered as the owner of the GitHub repository, and the artifact ID is considered as the repo name. Therefore, the dependencies that have GitHub repositories but do not follow this method of naming will not be identified. 

> Maven source jar file links for the previous version and new version of the updated dependency are also added as metadata to the JSON file if they exist.

- Fixes #70 

>The scope of the updated dependency is checked before adding as a JSON data file. If the scope is "test", it will not be added.

- Handle flaky tests

> To ensure that the build does not fail due to flaky tests, if the build has failed due to test failures, it will be attempted again 3 times for both the previous commit and the commit with the breaking update. 