### PR TITLE
Update json data files with new fields 

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,5 +102,5 @@ As of Jul 5 2023:
     - 0 (0.00%) have dependency resolution failures with the updated dependency.
     - 0 (0.00%) fail after updating the dependency due to maven enforcer failures.
     - 0 (0.00%) fail due to unknown failures after updating the dependency.
-    - 3 (100.00%) could not be locally reproduced.
+  * Reproduction has been attempted for 3 breaking updates, and 3 (100.00%) could not be locally reproduced.
   * For the remaining 1394 breaking updates in the dataset, reproduction has not been attempted yet.

--- a/schemas/breaking-update-metadata.schema.json
+++ b/schemas/breaking-update-metadata.schema.json
@@ -25,7 +25,7 @@
         }
       ]
     },
-    "updateType": {
+    "updatedFileType": {
       "description": "The type of the updated dependency.",
       "anyOf": [
         {

--- a/schemas/breaking-update.schema.json
+++ b/schemas/breaking-update.schema.json
@@ -50,14 +50,28 @@
         "other"
       ]
     },
-    "type": {
-      "description": "The type of user that introduced the breaking update",
+    "prAuthor": {
+      "description": "The type of user that introduced the breaking update PR",
       "type": "string",
       "enum": [
         "human",
-        "dependabot",
-        "renovate",
-        "other"
+        "bot"
+      ]
+    },
+    "preCommitAuthor": {
+      "description": "The type of user that introduced the previous commit of the breaking update",
+      "type": "string",
+      "enum": [
+        "human",
+        "bot"
+      ]
+    },
+    "breakingCommitAuthor": {
+      "description": "The type of user that introduced the breaking update commit",
+      "type": "string",
+      "enum": [
+        "human",
+        "bot"
       ]
     },
     "reproductionStatus": {

--- a/scripts/calculate_stats.sh
+++ b/scripts/calculate_stats.sh
@@ -30,6 +30,6 @@ As of $(LC_TIME=en_US.UTF-8 date +"%b %-d %Y"):
     - $num_dependency_resolution_failure ($(get_fraction_as_percentage "$num_dependency_resolution_failure" "$num_attempted")) have dependency resolution failures with the updated dependency.
     - $num_mvn_enforcer_failure ($(get_fraction_as_percentage "$num_mvn_enforcer_failure" "$num_attempted")) fail after updating the dependency due to maven enforcer failures.
     - $num_unknown_failure ($(get_fraction_as_percentage "$num_unknown_failure" "$num_attempted")) fail due to unknown failures after updating the dependency.
-    - $num_unreproducible ($(get_fraction_as_percentage "$num_unreproducible" "$num_attempted")) could not be locally reproduced.
+  * Reproduction has been attempted for $num_attempted breaking updates, and $num_unreproducible ($(get_fraction_as_percentage "$num_unreproducible" "$num_attempted")) could not be locally reproduced.
   * For the remaining $num_not_attempted breaking updates in the dataset, reproduction has not been attempted yet."
 export STATS

--- a/src/test/java/miner/BreakingUpdateTest.java
+++ b/src/test/java/miner/BreakingUpdateTest.java
@@ -97,15 +97,41 @@ public class BreakingUpdateTest extends GitHubMinerTestBase {
     }
 
     @Test
-    public void typeIsCorrectlyIdentified() {
+    public void prAuthorTypeIsCorrectlyIdentified() {
         List<String> expected = List.of(
-                "dependabot",
+                "bot",
                 "human",
-                "dependabot",
-                "dependabot",
-                "renovate"
+                "bot",
+                "bot",
+                "bot"
         );
         for (int i = 0; i < breakingUpdates.size(); i++)
-            assertEquals(expected.get(i), breakingUpdates.get(i).type);
+            assertEquals(expected.get(i), breakingUpdates.get(i).prAuthor);
+    }
+
+    @Test
+    public void previousCommitAuthorTypeIsCorrectlyIdentified() {
+        List<String> expected = List.of(
+                "human",
+                "human",
+                "human",
+                "human",
+                "human"
+        );
+        for (int i = 0; i < breakingUpdates.size(); i++)
+            assertEquals(expected.get(i), breakingUpdates.get(i).preCommitAuthor);
+    }
+
+    @Test
+    public void breakingCommitAuthorTypeIsCorrectlyIdentified() {
+        List<String> expected = List.of(
+                "bot",
+                "human",
+                "bot",
+                "bot",
+                "bot"
+        );
+        for (int i = 0; i < breakingUpdates.size(); i++)
+            assertEquals(expected.get(i), breakingUpdates.get(i).breakingCommitAuthor);
     }
 }


### PR DESCRIPTION
The newly suggested fields prAuthor, preCommitAuthor, and breakingCommitAuthor are added to the JSON file. 
The issue with uploading the log file to the cache repo is also fixed.