### PR TITLE
Update PullRequestFilters to use Instant for date comparisons and upd…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.330</version>
+            <version>2.0-rc.6</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/src/main/java/miner/GitHubMiner.java
+++ b/src/main/java/miner/GitHubMiner.java
@@ -193,12 +193,12 @@ public class GitHubMiner {
 
         while (pullRequests.hasNext()) {
             List<GHPullRequest> nextPage = pullRequests.nextPage();
-            if (PullRequestFilters.createdBefore(cutoffDate).test(nextPage.get(0))) {
+            if (PullRequestFilters.createdBefore(cutoffDate.toInstant()).test(nextPage.get(0))) {
                 log.info("Checked all PRs for " + repo + " created after " + cutoffDate);
                 break;
             }
             nextPage.stream()
-                    .takeWhile(PullRequestFilters.createdBefore(cutoffDate).negate())
+                    .takeWhile(PullRequestFilters.createdBefore(cutoffDate.toInstant()).negate())
                     .filter(PullRequestFilters.changesOnlyDependencyVersionInPomXML)
                     .filter(PullRequestFilters.breaksBuild)
                     .map(BreakingUpdate::new)

--- a/src/main/java/miner/PullRequestFilters.java
+++ b/src/main/java/miner/PullRequestFilters.java
@@ -3,7 +3,7 @@ package miner;
 import org.kohsuke.github.*;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -77,10 +77,10 @@ public class PullRequestFilters {
      * @return a {@link java.util.function.Predicate} over {@link org.kohsuke.github.GHPullRequest}s returning
      *         true if a PR was created before the given date, false otherwise.
      */
-    public static Predicate<GHPullRequest> createdBefore(Date cutoffDate) {
+    public static Predicate<GHPullRequest> createdBefore(Instant cutoffDate) {
         return pr -> {
             try {
-                return pr.getCreatedAt().before(cutoffDate);
+                return pr.getCreatedAt().isBefore(cutoffDate);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/test/java/miner/PullRequestFiltersTest.java
+++ b/src/test/java/miner/PullRequestFiltersTest.java
@@ -5,7 +5,6 @@ import org.kohsuke.github.GHPullRequest;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,7 +31,7 @@ class PullRequestFiltersTest extends GitHubMinerTestBase {
             gitHub.getRepository("iluwatar/java-design-patterns").getPullRequest(1976),
             gitHub.getRepository("alibaba/fastjson").getPullRequest(4233)
         );
-        Date cutoffDate = Date.from(Instant.parse("2022-04-01T00:00:00.00Z"));
+        Instant cutoffDate = Instant.parse("2022-04-01T00:00:00.00Z");
         assertEquals(2, prs.stream().filter(PullRequestFilters.createdBefore(cutoffDate)).count());
     }
 }


### PR DESCRIPTION
This pull request updates how the code handles pull request creation dates by switching from `Date` to `Instant` for better time precision and modern Java practices. It also updates the GitHub API dependency to a newer version. The most important changes are:

**Dependency Update:**
* Upgraded the `github-api` dependency from version `1.330` to `2.0-rc.6` in `pom.xml`, ensuring compatibility with newer features and bug fixes.

**Date Handling Modernization:**
* Changed the `createdBefore` method and its usages to accept and use `Instant` instead of `Date`, improving time handling accuracy and consistency with modern Java APIs. [[1]](diffhunk://#diff-c3971a10cc33919fc9a31b0e749d6b74c65920776e025784e94d397a003e3036L6-R6) [[2]](diffhunk://#diff-c3971a10cc33919fc9a31b0e749d6b74c65920776e025784e94d397a003e3036L80-R83) [[3]](diffhunk://#diff-6856c3fb3655364f938d17423dfd09f4b2a4eee6f3765e01c519cb194341b4aeL196-R201) [[4]](diffhunk://#diff-b2ce71052cb4a9f546bbebab6066cb2e1338c3eae98a8e1475f627f7b3062a24L8) [[5]](diffhunk://#diff-b2ce71052cb4a9f546bbebab6066cb2e1338c3eae98a8e1475f627f7b3062a24L35-R34)

These changes help future-proof the code and make it more robust when dealing with timestamps.…ate GitHub API dependency version